### PR TITLE
로그인/로그아웃시에 scope 참조할 수 있도록 수정

### DIFF
--- a/sms_login.gemspec
+++ b/sms_login.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'sms_login'
-  s.version     = '0.1.5'
-  s.date        = '2017-06-08'
+  s.version     = '0.1.6'
+  s.date        = '2017-06-29'
   s.summary     = "SMS로 받은 링크를 통해 로그인하는 기능"
   s.description = "핸드폰 번호를 입력하면 해당 번호로 로그인 토큰을 포함한 링크를 문자로 발송해서 로그인할 수 있도록 합니다."
   s.authors     = ["Bonghyun Kim"]


### PR DESCRIPTION
- sign_in_with_sms_login_code, sign_in_with_sms_login_token 함수에서 심볼로된 모델명을 옵션으로 받도록 수정
- 심볼 모델이 있으면 request.env['warden']의 set_user, logout에 scope을 설정하여 준다.